### PR TITLE
Update dependencies to remove high severity vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,17 @@ sudo: false
 language: node_js
 node_js:
   - "11"
-os:
-  - osx
-  - linux
+
+jobs:
+  include:
+    - os: linux
+      services:
+      - xvfb
+    - os: osx
 
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
+      export CXX="g++-4.9" CC="gcc-4.9";
     fi
 
 install:

--- a/package-lock.json
+++ b/package-lock.json
@@ -421,12 +421,12 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^4.1.0",
+				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
 			}
 		},


### PR DESCRIPTION
This change set bumps the version of https-proxy-agent to prevent a possible high-severity machine-in-the-middle attack.

[npmjs security advisory](https://www.npmjs.com/advisories/1184)